### PR TITLE
Must guaruntee a MemberExpression has been hit while traveling up the tr...

### DIFF
--- a/lib/groundskeeper.js
+++ b/lib/groundskeeper.js
@@ -142,7 +142,7 @@ Groundskeeper.prototype.removeConsole = function (node) {
             node = node.parent;
         }
 
-        if (
+        if (node &&
             node.parent.type === type.MemberExpression &&
             (
                 node.parent.source().indexOf('window') !== -1 ||
@@ -153,7 +153,7 @@ Groundskeeper.prototype.removeConsole = function (node) {
         }
 
 
-        if (node.parent.type === type.CallExpression) {
+        if (node && node.parent.type === type.CallExpression) {
             node = node.parent;
 
             if (node.parent.type === type.ExpressionStatement) {


### PR DESCRIPTION
...ee

If a `console` identifier is in the source without accessing any of it
members this will fail to remove it and result in a runtime error.
