### PR TITLE
Must guaruntee a MemberExpression has been hit while traveling up the tree

### DIFF
--- a/lib/groundskeeper.js
+++ b/lib/groundskeeper.js
@@ -138,7 +138,7 @@ Groundskeeper.prototype.clean = function (data) {
 Groundskeeper.prototype.removeConsole = function (node) {
 
     if (node.type === type.Identifier && node.source() === 'console') {
-        while (node.type !== type.MemberExpression) {
+        while (node && node.type !== type.MemberExpression) {
             node = node.parent;
         }
 


### PR DESCRIPTION
If a `console` identifier is in the source without accessing any of it's
members groundskeeper will fail to remove it and result in a runtime error.
