### PR TITLE
Added support for removing pragmas that are in block comments

### DIFF
--- a/lib/groundskeeper.js
+++ b/lib/groundskeeper.js
@@ -247,13 +247,16 @@ Groundskeeper.prototype.removePragmas = function (comments, source, pragmas) {
         ranges = comments
             .map(function (comment) {
 
-                // if the comment is a line comment
-                // and that comment contains a 'pragma'
-                // and that pragma is not on the pragmas keep list
+
+                var matches = pragmaMatcher.exec(comment.value.trim());
+                var pragmaName = matches && matches[1];
+
+                // if the comment
+                // * only contains a `pragma`
+                // * that pragma is not on the pragmas keep list
                 if (
-                    comment.type === 'Line' &&
-                    pragmaMatcher.test(comment.value) &&
-                    pragmas.indexOf(comment.value.replace(pragmaMatcher, '$1')) === -1
+                    pragmaName &&
+                    pragmas.indexOf(pragmaName) === -1
                 ) {
                     return comment.range;
                 }

--- a/test/fixtures/pragmas/block-comment.clean.js
+++ b/test/fixtures/pragmas/block-comment.clean.js
@@ -1,0 +1,26 @@
+function merge(target) {
+    console.dir(target, arguments);
+
+    var objects = Array.prototype.slice.call(arguments, 1),
+        keys = [],
+        log = console.log;
+
+    objects.forEach(function (val, idx) {
+        keys = Object.keys(val);
+        keys.forEach(function (val) {
+            target[val] = objects[idx][val];
+            App.logger.warn("Hello World");
+            console.log(keys);
+            debugger;
+            
+        });
+    });
+
+    App.logger.log("Hello World");
+
+    console.log('all duplicates, get more');
+    console.log("loadImageInCache():::::", index+1, index+1 % 2);
+    console.log("external() open()", url, scrollee);
+
+    
+}

--- a/test/fixtures/pragmas/block-comment.js
+++ b/test/fixtures/pragmas/block-comment.js
@@ -1,0 +1,30 @@
+function merge(target) {
+    console.dir(target, arguments);
+
+    var objects = Array.prototype.slice.call(arguments, 1),
+        keys = [],
+        log = console.log;
+
+    objects.forEach(function (val, idx) {
+        keys = Object.keys(val);
+        keys.forEach(function (val) {
+            target[val] = objects[idx][val];
+            App.logger.warn("Hello World");
+            console.log(keys);
+            debugger;
+            /*<development> */
+            clean('this').developmentPragma;
+            /*</development> */
+        });
+    });
+
+    App.logger.log("Hello World");
+
+    console.log('all duplicates, get more');
+    console.log("loadImageInCache():::::", index+1, index+1 % 2);
+    console.log("external() open()", url, scrollee);
+
+    /*<validation> */
+    clean('this').validationPragma;
+    /*</validation> */
+}

--- a/test/pragma.test.js
+++ b/test/pragma.test.js
@@ -25,6 +25,21 @@ module.exports = {
         assert.equal(cleaner.toString(), clean);
     },
 
+    'remove pragmas that are in block comments': function () {
+        var file = fixture('pragmas/block-comment'),
+            clean = fixture('pragmas/block-comment.clean'),
+            cleaner = groundskeeper({
+                console: true,
+                'debugger': true
+            });
+
+        var start = +new Date();
+        cleaner.write(file);
+        console.log(+new Date() - start + ' ms');
+
+        assert.equal(cleaner.toString(), clean);
+    },
+
     'remove validation pragma only': function () {
         var file = fixture('pragmas/validation'),
             clean = fixture('pragmas/validation.clean'),


### PR DESCRIPTION
Why I add this is because I want to use groundskeeper together with CoffeeScript. In CoffeeScript you cannot produce single-line JS-comments.

The best you can do in CS is:

``` coffeescript
    ###<pragma>###
    logicThatShouldBeRemoved()
    ###</pragma>###
```

Which produces JavaScript:

``` js
    /*<pragma> */
    logicThatShouldBeRemoved();
    /*</pragma> */
```

Now it ignores the `comment.type`, trims the whitespace off `comment.value` and compares with that.
