### PR TITLE
Update falafel from ~0.3.1 to ~1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 groundskeeper
 =============
 
-__Current Version:__ 0.1.11
+__Current Version:__ 0.1.12
 
 [![Build Status](https://secure.travis-ci.org/Couto/groundskeeper.png?branch=master)](https://travis-ci.org/Couto/groundskeeper)
 [![Dependencies Status](https://david-dm.org/Couto/groundskeeper.png?branch=master)](https://david-dm.org/Couto/groundskeeper)

--- a/bin/groundskeeper
+++ b/bin/groundskeeper
@@ -10,7 +10,7 @@
  * @author Luis Couto
  * @organization 15minuteslate.net
  * @contact couto@15minuteslate.net
- * @version 0.1.11
+ * @version 0.1.12
  * @requires path, fs, exec, commander.js, colors, log.js
  * @license ISC 2014, Luis Couto
  *

--- a/lib/groundskeeper.js
+++ b/lib/groundskeeper.js
@@ -10,7 +10,7 @@
  * @author Luis Couto
  * @organization 15minuteslate.net
  * @contact couto@15minuteslate.net
- * @version 0.1.11
+ * @version 0.1.12
  * @requires falafel, stream, util, esprima
  * @license ISC 2014, Luis Couto
  */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "groundskeeper",
   "description": "Pragmas and console statements remover",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "author": "Luis Couto <couto@15minuteslate.net> (15minuteslate.net)",
   "license": "ISC",
   "repository": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "colors": "~0.6.0-1",
     "esprima": "~1.2.0",
-    "falafel": "~0.3.1",
+    "falafel": "~1.1.0",
     "commander": "~2.2.0"
   },
   "devDependencies": {

--- a/test/fixtures/debugger/debugger.clean.js
+++ b/test/fixtures/debugger/debugger.clean.js
@@ -17,6 +17,7 @@ function merge(target) {
             clean('this').developmentPragma;
             //</development>
         });
+        
         DEBUGGER
         Debug.write('example');
     });


### PR DESCRIPTION
Update falafel package from 0.3.1 to 1.1.0.

The package upgrade was needed because falafel 0.3.1 had an checked-in version of esprima with a non-existent rev string that breaks npm shrinkwrap.

`npm run test` returns 18/18 passes.

